### PR TITLE
init lambroll

### DIFF
--- a/infra/lambroll/.lambdaignore
+++ b/infra/lambroll/.lambdaignore
@@ -1,0 +1,9 @@
+.lambdaignore
+function.json
+function.jsonnet
+function_url.json
+function_url.jsonnet
+function.zip
+.git/*
+.terraform/*
+terraform.tfstate

--- a/infra/lambroll/.lambdaignore
+++ b/infra/lambroll/.lambdaignore
@@ -1,9 +1,0 @@
-.lambdaignore
-function.json
-function.jsonnet
-function_url.json
-function_url.jsonnet
-function.zip
-.git/*
-.terraform/*
-terraform.tfstate

--- a/infra/lambroll/function.json
+++ b/infra/lambroll/function.json
@@ -1,0 +1,30 @@
+{
+  "Architectures": ["arm64"],
+  "Code": {
+    "ImageUri": "{{ tfstate `module.lambda.aws_lambda_function.function.image_uri` }}"
+  },
+  "EphemeralStorage": {
+    "Size": 512
+  },
+  "FunctionName": "sample-lambda-cicd-dev-lambda",
+  "LoggingConfig": {
+    "LogFormat": "Text",
+    "LogGroup": "/aws/lambda/sample-lambda-cicd-dev-lambda"
+  },
+  "MemorySize": 128,
+  "PackageType": "Image",
+  "Role": "{{ tfstate `module.lambda.aws_iam_role.lambda_role.arn` }}",
+  "SnapStart": {
+    "ApplyOn": "None"
+  },
+  "Tags": {
+    "Environment": "dev",
+    "ManagedBy": "terraform",
+    "Name": "sample-lambda-cicd-dev-lambda",
+    "Project": "sample-lambda-cicd"
+  },
+  "Timeout": 30,
+  "TracingConfig": {
+    "Mode": "PassThrough"
+  }
+}


### PR DESCRIPTION
```bash
# AWSを参照して、`.lambdaignore`と、`function.json`が作成される。
$ lambroll init --function-name sample-lambda-cicd-dev-lambda --download

$ TFE_TOKEN=xxx perman-aws-vault exec lambroll diff --tfstate=remote://app.terraform.io/RintaroooOrg/dev-lambda --log-level=debug
2025/02/06 15:20:24 [info] lambroll v1.1.3
2025/02/06 15:20:25 [debug] list tags Resource arn:aws:lambda:ap-northeast-1:[AWS account ID]:function:sample-lambda-cicd-dev-lambda
2025/02/06 15:20:25 [debug] Image URL=[AWS account ID].dkr.ecr.ap-northeast-1.amazonaws.com/sample-lambda-cicd-dev-lambda:0.0.1
```